### PR TITLE
🌟 Feat: 내 정보 - 목록 페이지 마크업 완료(교환 목록, 후기 목록, 최근 본 글)

### DIFF
--- a/app/user/exchange-list/page.tsx
+++ b/app/user/exchange-list/page.tsx
@@ -1,0 +1,103 @@
+import Image from "next/image"
+import EmptyState from "@/components/ui/EmptyState"
+
+type Exchange = {
+  id: number
+  bookImage: string
+  title: string
+  content: string
+  time: string
+}
+
+export default function ExchangeListPage() {
+  const exchanges: Exchange[] = [
+    {
+      id: 1,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 2,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 3,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 4,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+  ]
+
+  const isEmpty = exchanges.length === 0
+
+  if (isEmpty) {
+    return (
+      <div className="min-h-screen w-full bg-bg-primary">
+        <div className="px-4 py-6">
+          <EmptyState 
+            title="아직 교환 내역이 없어요."
+            description="첫 번째 교환을 시작해보세요!"
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-bg-primary">
+      <div className="px-4 py-6 max-w-md mx-auto">
+        {/* 목록 */}
+        <div>
+          {exchanges.map((item, index) => (
+            <div key={item.id}>
+              {/* 목록 아이템 */}
+              <div className="flex gap-4 py-4">
+                {/* 책 이미지 */}
+                <div className="w-18 h-18 flex-shrink-0">
+                  <Image
+                    src={item.bookImage}
+                    alt={item.title}
+                    width={64}
+                    height={80}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+
+                {/* 내용 */}
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-base font-bold text-font-dark mb-1 truncate">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm text-font-dark line-clamp-2 mb-2">
+                    {item.content}
+                  </p>
+                  <p className="text-xs text-gray-dark">
+                    {item.time}
+                  </p>
+                </div>
+              </div>
+
+              {/* 구분선 */}
+              {index < exchanges.length - 1 && (
+                <div className="border-b border-border-primary" />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/user/recent/page.tsx
+++ b/app/user/recent/page.tsx
@@ -1,0 +1,103 @@
+import Image from "next/image"
+import EmptyState from "@/components/ui/EmptyState"
+
+type Recent = {
+  id: number
+  bookImage: string
+  title: string
+  content: string
+  time: string
+}
+
+export default function RecentPage() {
+  const recents: Recent[] = [
+    {
+      id: 1,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 2,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 3,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+    {
+      id: 4,
+      bookImage: "/favicon.ico",
+      title: "책 제목",
+      content: "계산을 너무 계산을 너무 계산을 너무 계산을 내용 계산을 내용...",
+      time: "작성 시간"
+    },
+  ]
+
+  const isEmpty = recents.length === 0
+
+  if (isEmpty) {
+    return (
+      <div className="min-h-screen w-full bg-bg-primary">
+        <div className="px-4 py-6">
+          <EmptyState 
+            title="아직 둘러본 책이 없어요."
+            description="동네 책장을 구경해보세요!"
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-bg-primary">
+      <div className="px-4 py-6 max-w-md mx-auto">
+        {/* 목록 */}
+        <div>
+          {recents.map((item, index) => (
+            <div key={item.id}>
+              {/* 목록 아이템 */}
+              <div className="flex gap-4 py-4">
+                {/* 책 이미지 */}
+                <div className="w-18 h-18 flex-shrink-0">
+                  <Image
+                    src={item.bookImage}
+                    alt={item.title}
+                    width={64}
+                    height={80}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+
+                {/* 내용 */}
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-base font-bold text-font-dark mb-1 truncate">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm text-font-dark line-clamp-2 mb-2">
+                    {item.content}
+                  </p>
+                  <p className="text-xs text-gray-dark">
+                    {item.time}
+                  </p>
+                </div>
+              </div>
+
+              {/* 구분선 */}
+              {index < recents.length - 1 && (
+                <div className="border-b border-border-primary" />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/user/reviews/page.tsx
+++ b/app/user/reviews/page.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useState } from "react"
+import Image from "next/image"
+import EmptyState from "@/components/ui/EmptyState"
+
+type Review = {
+  id: number
+  profileImage: string
+  nickname: string
+  date: string
+  content: string
+}
+
+export default function ReviewsPage() {
+  const [activeTab, setActiveTab] = useState<"received" | "written">("received")
+
+  const receivedReviews: Review[] = [
+      {
+      id: 1,
+      profileImage: "/favicon.ico",
+      nickname: "닉네임",
+      date: "2024.01.15",
+      content: "후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다.",
+    },
+    {
+      id: 2,
+      profileImage: "/favicon.ico",
+      nickname: "닉네임",
+      date: "2024.01.14",
+      content: "후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다.",
+    },
+    {
+      id: 3,
+      profileImage: "/favicon.ico",
+      nickname: "닉네임",
+      date: "2024.01.13",
+      content: "후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다.",
+    },
+    
+  ]
+
+  const writtenReviews: Review[] = [
+    {
+    id: 1,
+    profileImage: "/favicon.ico",
+    nickname: "닉네임",
+    date: "2024.01.12",
+    content: "후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다.",
+  },
+  {
+    id: 2,
+    profileImage: "/favicon.ico",
+    nickname: "닉네임",
+    date: "2024.01.11",
+    content: "후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다. 후기 내용 입니다.",
+  },
+  ]
+
+  const currentReviews = activeTab === "received" ? receivedReviews : writtenReviews
+  const isEmpty = currentReviews.length === 0
+
+  return (
+    <div className="min-h-screen w-full bg-bg-primary">
+      <div className="px-4 py-6 max-w-md mx-auto">
+        {/* 탭 */}
+        <div className="flex mb-6">
+          <button
+            onClick={() => setActiveTab("received")}
+            className={`flex-1 pb-2 text-base font-medium border-b-2 transition ${
+              activeTab === "received"
+                ? "border-brown-accent text-font-dark"
+                : "border-transparent text-gray-dark"
+            }`}
+          >
+            받은 후기
+          </button>
+          <button
+            onClick={() => setActiveTab("written")}
+            className={`flex-1 pb-2 text-base font-medium border-b-2 transition ${
+              activeTab === "written"
+                ? "border-brown-accent text-font-dark"
+                : "border-transparent text-gray-dark"
+            }`}
+          >
+            작성한 후기
+          </button>
+        </div>
+
+        {/* 빈 상태 */}
+          {isEmpty ? (
+            <EmptyState
+              title={
+                activeTab === "received" 
+                  ? "아직 받은 후기가 없어요." 
+                  : "아직 작성한 후기가 없어요."
+              }
+              description={
+                activeTab === "received"
+                  ? "거래가 완료되면 교환자들의 후기를 확인할 수 있어요."
+                  : "거래가 끝나면 교환자에게 후기를 남길 수 있어요."
+              }
+            />
+          ) : (
+          /* 목록 */
+          <div>
+            {currentReviews.map((item, index) => (
+              <div key={item.id}>
+                {/* 목록 아이템 */}
+                <div className="flex gap-4 py-4">
+                  {/* 프로필 이미지 */}
+                  <div className="w-18 h-18 flex-shrink-0">
+                    <Image
+                      src={item.profileImage}
+                      alt={item.nickname}
+                      width={64}
+                      height={64}
+                      className="w-full h-full object-cover rounded-full"
+                    />
+                  </div>
+
+                  {/* 내용 */}
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-base font-bold text-font-dark mb-1">
+                      {item.nickname}
+                    </h3>
+                    <p className="text-xs text-gray-dark mb-2">
+                      {item.date}
+                    </p>
+                    <p className="text-sm text-font-dark leading-relaxed">
+                      {item.content}
+                    </p>
+                  </div>
+                </div>
+
+                {/* 구분선 */}
+                {index < currentReviews.length - 1 && (
+                  <div className="border-b border-border-primary" />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📋 PR 설명
목록 페이지 마크업 작업 완료 (교환 목록, 최근 본 글, 후기 목록)

## 🔗 관련 이슈
- Closes #23 

## 📝 변경 사항 상세
- 교환 목록 페이지 생성 (`app/user/exchange-list/page.tsx`)
- 최근 본 글 페이지 생성 (`app/user/recent/page.tsx`)
- 후기 목록 페이지 생성 (`app/user/reviews/page.tsx`)
- 목록 아이템 구현 (이미지, 제목/닉네임, 내용, 시간/날짜)
- 후기 탭 목록 구현 (받은 후기 / 작성한 후기)

## ✅ 체크리스트

<!-- 아래 항목들을 확인하고 체크해주세요 -->

- [x] 코드 리뷰를 위해 자신의 코드를 검토했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 새로운 기능이 있으면 테스트를 추가했습니다
- [ ] 기존 테스트가 모두 통과합니다
- [x] ESLint 및 Prettier 규칙을 준수합니다
- [x] 추가 정보나 가정사항이 없습니다

## 📸 스크린샷 / 결과물
<img width="1040" height="994" alt="image" src="https://github.com/user-attachments/assets/004c15a4-8d36-4fb3-bb6f-b135f3b65d5b" />
<img width="904" height="970" alt="image" src="https://github.com/user-attachments/assets/e90d8131-289b-44d0-9642-7574f5b40797" />
<img width="944" height="1118" alt="image" src="https://github.com/user-attachments/assets/30fdbad0-073d-4555-8565-e9e729425481" />
<img width="730" height="928" alt="image" src="https://github.com/user-attachments/assets/17835ea5-73b9-44bf-84d8-4df8b5696c7b" />


## 📚 참고 자료
- 피그마 디자인 시안
- EmptyState 컴포넌트

## ⚠️ 주의사항
현재 마크업만 완료된 상태로, 다음 작업이 필요합니다
- 헤더 컴포넌트 추가
- api 연결 및 실제 데이터 표시
- 목록 아이템 클릭 이벤트
- 프로필/책 이미지 없을 때 기본 이모지 처리
- 무한 스크롤 가능
