### PR TITLE
🌟 Feat: 차단 목록 페이지 마크업 완료

### DIFF
--- a/app/user/blocked/page.tsx
+++ b/app/user/blocked/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import EmptyState from '@/components/ui/EmptyState';
+
+type BlockedUser = {
+  id: number;
+  name: string;
+  profileImage?: string;
+};
+
+export default function BlockedListPage() {
+  const [blockedUsers, setBlockedUsers] = useState<BlockedUser[]>([
+    { id: 1, name: '짱구', profileImage: '/favicon.ico' },
+    { id: 2, name: '신형만' },  // 프사 없음
+    { id: 3, name: '봉미선', profileImage: '/favicon.ico' },
+    { id: 4, name: '짱아' },  // 프사 없음
+    { id: 5, name: '맹구', profileImage: '/favicon.ico' },
+    { id: 6, name: '훈이' },  // 프사 없음
+    { id: 7, name: '철수', profileImage: '/favicon.ico' },
+    { id: 8, name: '유리' },  // 프사 없음
+  ]);
+
+  const handleUnblock = (userId: number) => {
+    console.log('차단 해제:', userId);
+    setBlockedUsers(blockedUsers.filter(user => user.id !== userId));
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-bg-primary pb-20">
+      <div className="px-4 py-6 max-w-md mx-auto">
+        {/* 차단 목록 또는 빈 상태 */}
+        {blockedUsers.length > 0 ? (
+          <div className="space-y-3">
+            {blockedUsers.map((user) => (
+              <div 
+                key={user.id}
+                className="flex items-center justify-between bg-white rounded-xl p-4"
+              >
+                {/* 프로필 */}
+                <div className="flex items-center gap-3">
+                  {/* 프로필 이미지 또는 없을 때 이니셜 */}
+                  <div className="w-12 h-12 rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center bg-brown-accent">
+                    {user.profileImage ? (
+                      <Image
+                        src={user.profileImage}
+                        alt={user.name}
+                        width={48}
+                        height={48}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-white font-semibold text-lg">
+                        {user.name.charAt(0).toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-base text-font-dark">{user.name}</span>
+                </div>
+
+                {/* 차단 해제 버튼 */}
+                <button
+                  onClick={() => handleUnblock(user.id)}
+                  className="px-4 py-2 bg-brown-accent text-white text-sm rounded-lg font-medium"
+                >
+                  차단 해제
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState 
+            title="차단한 사용자가 없습니다"
+            description="차단한 사용자가 여기에 표시됩니다"
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 PR 설명
차단 목록 페이지를 구현했습니다.

## 🔗 관련 이슈
- Closes #40 

## 📝 변경 사항 상세

<!-- 구체적인 변경 내용을 작성해주세요 -->

- 차단된 사용자 목록 표시
- 차단한 사용자가 없을 때 EmptyState 표시
- 네비게이션 바에 가려지지 않도록 하단 여백 추가

## ✅ 체크리스트

<!-- 아래 항목들을 확인하고 체크해주세요 -->

- [x] 코드 리뷰를 위해 자신의 코드를 검토했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 새로운 기능이 있으면 테스트를 추가했습니다
- [ ] 기존 테스트가 모두 통과합니다
- [x] ESLint 및 Prettier 규칙을 준수합니다
- [x] 추가 정보나 가정사항이 없습니다

## 📸 스크린샷 / 결과물
<img width="1010" height="1476" alt="image" src="https://github.com/user-attachments/assets/fa005e1c-afb7-4b92-ae49-c76c543719b2" />

## 📚 참고 자료
피그마 시안

## ⚠️ 주의사항
현재 마크업만 구현된 상태입니다.
프로필 이미지가 없는 경우 사용자 이름의 첫 글자로 대체됩니다.
