### PR TITLE
✨ feat: 후기 작성 대상 정보 추가

### DIFF
--- a/app/chat/[roomId]/ChatRoom.tsx
+++ b/app/chat/[roomId]/ChatRoom.tsx
@@ -96,7 +96,10 @@ export default function ChatRoom({ roomId }: { roomId: string }) {
               </p>
             </div>
           </article>
-          <ChatTransactionButton />
+          <ChatTransactionButton
+          orderId={activeRoom?._id || 0}
+          productId={activeRoom?.resourceId || 0}
+          />
         </div>
       </div>
 

--- a/components/ui/ChatTransactionButton.tsx
+++ b/components/ui/ChatTransactionButton.tsx
@@ -5,7 +5,12 @@ import { CompleteIcon } from '@/app/components/icons/Complete';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-export default function ChatTransactionButton() {
+type Props = {
+  orderId: number
+  productId: number
+}
+
+export default function ChatTransactionButton({ orderId, productId }: Props) {
   const [isCompleted, setIsCompleted] = useState(false);
   const router = useRouter();
 
@@ -17,7 +22,7 @@ export default function ChatTransactionButton() {
 
   const handleReview = () => {
     // 후기 작성 페이지로 이동
-    router.push('/reviews/write');
+    router.push(`/reviews/write?orderId=${orderId}&productId=${productId}`);
     console.log('후기 작성하기');
   };
   return (


### PR DESCRIPTION
## 📋 PR 설명
후기 작성 버튼 클릭 시 어떤 상품에 대한 후기인지 대상 정보를 전달하는 로직 추가

## 🔗 관련 이슈
- Closes #76 

## 📝 변경 사항 상세
- ChatTransactionButton에 orderId, productId props 추가
- 후기 작성 페이지 이동 시 URL에 orderId, productId 파라미터 포함
- ChatRoom에서 orderId는 activeRoom._id, productId는 activeRoom.resourceId로 전달

## ✅ 체크리스트

<!-- 아래 항목들을 확인하고 체크해주세요 -->

- [x] 코드 리뷰를 위해 자신의 코드를 검토했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 새로운 기능이 있으면 테스트를 추가했습니다
- [ ] 기존 테스트가 모두 통과합니다
- [x] ESLint 및 Prettier 규칙을 준수합니다
- [x] 추가 정보나 가정사항이 없습니다

## ⚠️ 주의사항
- 교환 완료 API 추후 연동 필요
