### PR TITLE
🌟 Feat:프로필 수정 페이지 주소 변경 기능 추가

### DIFF
--- a/app/user/profile-edit/page.tsx
+++ b/app/user/profile-edit/page.tsx
@@ -10,6 +10,7 @@ import { getUser, setUser as setLocalUser } from "@/utils/user"
 import { getAxios, handleAxiosError } from "@/utils/axios"
 import type { UserDetail } from "@/types/user"
 import Script from "next/script"
+import { useUserStore } from "@/zustand/useUserStore"
 
 
 declare global {
@@ -26,6 +27,7 @@ declare global {
 export default function ProfileEditPage() {
   const router = useRouter()
   const currentUser = getUser()
+  const setUser = useUserStore((state) => state.setUser)
   
 
   const [nickname, setNickname] = useState(currentUser?.name || '')
@@ -122,6 +124,7 @@ export default function ProfileEditPage() {
       
       const updatedUser = { ...currentUser, ...updateData } as UserDetail
       setLocalUser(updatedUser)
+      setUser(updatedUser, true)
       
       alert('프로필이 변경되었습니다!')
       router.push('/user/mypage')


### PR DESCRIPTION
## 📋 PR 설명
프로필 수정 페이지에 주소 변경 기능 추가 및 변경 후 즉시 검색 필터링에 반영되도록 수정

## 🔗 관련 이슈
- Closes #88 

## 📝 변경 사항 상세
- 프로필 수정 페이지에 주소 변경 기능 추가 (다음 주소 API 사용)
- 주소 변경 후 localStorage와 zustand 상태 동시 업데이트
- 기존에는 주소 변경 후 새로고침해야 검색 필터링에 반영되는 버그 수정

## ✅ 체크리스트
- [x] 코드 리뷰를 위해 자신의 코드를 검토했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 새로운 기능이 있으면 테스트를 추가했습니다
- [x] 기존 테스트가 모두 통과합니다
- [x] ESLint 및 Prettier 규칙을 준수합니다
- [x] 추가 정보나 가정사항이 없습니다

## 📸 스크린샷 / 결과물
<img width="465" height="447" alt="image" src="https://github.com/user-attachments/assets/ef7f97e9-1875-43a5-bc2e-3f5e10edb84b" />


## ⚠️ 주의사항
- 기존 가입 유저 중 address 없는 경우 주소 필드 비어있을 수 있음
